### PR TITLE
PCHR-4231: Add BackstopJS tests for Leave Type Wizard

### DIFF
--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-colour-picker.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-colour-picker.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Page = require('../../../page-objects/leave-type-wizard');
+
+module.exports = async engine => {
+  const page = new Page(engine);
+
+  await page.init();
+  await page.openSection(2);
+  await page.toggleColourPicker();
+};

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-colour-picker.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-colour-picker.js
@@ -6,6 +6,7 @@ module.exports = async engine => {
   const page = new Page(engine);
 
   await page.init();
+  await page.fillTitleFieldIn();
   await page.openSection(2);
   await page.toggleColourPicker();
 };

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-general-section.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-general-section.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Page = require('../../../page-objects/leave-type-wizard');
+
+module.exports = async engine => {
+  const page = new Page(engine);
+
+  await page.init();
+};

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-input-errors.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-input-errors.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Page = require('../../../page-objects/leave-type-wizard');
+
+module.exports = async engine => {
+  const page = new Page(engine);
+
+  await page.init();
+  await page.submitForm();
+  await page.openSection(2);
+};

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-input-errors.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-input-errors.js
@@ -6,6 +6,7 @@ module.exports = async engine => {
   const page = new Page(engine);
 
   await page.init();
+  await page.fillTitleFieldIn();
   await page.submitForm();
   await page.openSection(2);
 };

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-settings-section.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-settings-section.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Page = require('../../../page-objects/leave-type-wizard');
+
+module.exports = async engine => {
+  const page = new Page(engine);
+
+  await page.init();
+  await page.openSection(2);
+};

--- a/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-settings-section.js
+++ b/engine_scripts/puppet/leave-type-wizard/leave-type-wizard-settings-section.js
@@ -6,5 +6,6 @@ module.exports = async engine => {
   const page = new Page(engine);
 
   await page.init();
+  await page.fillTitleFieldIn();
   await page.openSection(2);
 };

--- a/page-objects/leave-type-wizard.js
+++ b/page-objects/leave-type-wizard.js
@@ -1,0 +1,62 @@
+const Page = require('./page');
+const LEAVE_TYPE_WIZARD_ROOT_SELECTOR = 'leave-type-wizard';
+
+module.exports = class LeaveTypeWizard extends Page {
+  /**
+   * Opens section
+   *
+   * @param {Number} sectionIndex where `1` is the first section
+   */
+  async openSection (sectionIndex) {
+    await this.puppet.click(insideWizard(`.panel-default:nth-child(${sectionIndex})`));
+  }
+
+  /**
+   * Opens tab inside an active section
+   *
+   * @param {Number} tabIndex where `1` is the first tab
+   */
+  async openTab (tabIndex) {
+    await this.puppet.click(insideWizard(`.nav-tabs-stacked li:nth-child(${tabIndex})`));
+  }
+
+  /**
+   * Submits the wizard form
+   *
+   * @NOTE `this.puppet.click()` does not work on the button
+   * and throws `Error: Node is either not visible or not an HTMLElement`
+   * @see https://github.com/GoogleChrome/puppeteer/issues/2977
+   * @TODO fix this once there is a solution
+   */
+  async submitForm () {
+    await this.puppet.click(insideWizard('.panel-default:last-child'));
+    await this.puppet.click(insideWizard('.nav-tabs-stacked li:last-child'));
+    await this.puppet.evaluate(() => {
+      document.querySelector('.leave-type-wizard__next-section-button').click();
+    });
+  }
+
+  /**
+   * Toggles colour picker
+   */
+  async toggleColourPicker () {
+    await this.puppet.click(insideWizard('[palette]'));
+  }
+
+  /**
+   * Waits for the wizard to be ready by looking for a horizontal form
+   * that must be present in any section in any tab
+   */
+  async waitForReady () {
+    await this.puppet.waitFor(insideWizard('.form-horizontal'), { visible: true });
+  }
+};
+
+/**
+ * Builds a selector inside the leave type wizard
+ *
+ * @param {String} selector a path to an object inside the wizard
+ */
+function insideWizard (selector) {
+  return `${LEAVE_TYPE_WIZARD_ROOT_SELECTOR} ${selector}`;
+}

--- a/page-objects/leave-type-wizard.js
+++ b/page-objects/leave-type-wizard.js
@@ -1,5 +1,5 @@
 const Page = require('./page');
-const LEAVE_TYPE_WIZARD_ROOT_SELECTOR = 'leave-type-wizard';
+const WIZARD_ROOT = 'leave-type-wizard';
 
 module.exports = class LeaveTypeWizard extends Page {
   /**
@@ -7,7 +7,7 @@ module.exports = class LeaveTypeWizard extends Page {
    */
   async fillTitleFieldIn () {
     await this.openSection(1);
-    await this.puppet.focus(insideWizard('input:first-child'));
+    await this.puppet.focus(`${WIZARD_ROOT} input:first-child`);
     await this.puppet.keyboard.type('Title');
   }
 
@@ -17,7 +17,7 @@ module.exports = class LeaveTypeWizard extends Page {
    * @param {Number} sectionIndex where `1` is the first section
    */
   async openSection (sectionIndex) {
-    await this.puppet.click(insideWizard(`.panel-default:nth-child(${sectionIndex})`));
+    await this.puppet.click(`${WIZARD_ROOT} .panel-default:nth-child(${sectionIndex})`);
   }
 
   /**
@@ -26,7 +26,7 @@ module.exports = class LeaveTypeWizard extends Page {
    * @param {Number} tabIndex where `1` is the first tab
    */
   async openTab (tabIndex) {
-    await this.puppet.click(insideWizard(`.nav-tabs-stacked li:nth-child(${tabIndex})`));
+    await this.puppet.click(`${WIZARD_ROOT} .nav-tabs-stacked li:nth-child(${tabIndex})`);
   }
 
   /**
@@ -38,8 +38,8 @@ module.exports = class LeaveTypeWizard extends Page {
    * @TODO fix this once there is a solution
    */
   async submitForm () {
-    await this.puppet.click(insideWizard('.panel-default:last-child'));
-    await this.puppet.click(insideWizard('.nav-tabs-stacked li:last-child'));
+    await this.puppet.click(`${WIZARD_ROOT} .panel-default:last-child`);
+    await this.puppet.click(`${WIZARD_ROOT} .nav-tabs-stacked li:last-child`);
     await this.puppet.evaluate(() => {
       document.querySelector('.leave-type-wizard__next-section-button').click();
     });
@@ -49,7 +49,7 @@ module.exports = class LeaveTypeWizard extends Page {
    * Toggles colour picker
    */
   async toggleColourPicker () {
-    await this.puppet.click(insideWizard('[palette]'));
+    await this.puppet.click(`${WIZARD_ROOT} [palette]`);
   }
 
   /**
@@ -57,15 +57,6 @@ module.exports = class LeaveTypeWizard extends Page {
    * that must be present in any section in any tab
    */
   async waitForReady () {
-    await this.puppet.waitFor(insideWizard('.form-horizontal'), { visible: true });
+    await this.puppet.waitFor(`${WIZARD_ROOT} .form-horizontal`, { visible: true });
   }
 };
-
-/**
- * Builds a selector inside the leave type wizard
- *
- * @param {String} selector a path to an object inside the wizard
- */
-function insideWizard (selector) {
-  return `${LEAVE_TYPE_WIZARD_ROOT_SELECTOR} ${selector}`;
-}

--- a/page-objects/leave-type-wizard.js
+++ b/page-objects/leave-type-wizard.js
@@ -3,6 +3,15 @@ const LEAVE_TYPE_WIZARD_ROOT_SELECTOR = 'leave-type-wizard';
 
 module.exports = class LeaveTypeWizard extends Page {
   /**
+   * Fills Title field in
+   */
+  async fillTitleFieldIn () {
+    await this.openSection(1);
+    await this.puppet.focus(insideWizard('input:first-child'));
+    await this.puppet.keyboard.type('Title');
+  }
+
+  /**
    * Opens section
    *
    * @param {Number} sectionIndex where `1` is the first section

--- a/scenarios/la-absence-types.json
+++ b/scenarios/la-absence-types.json
@@ -5,8 +5,24 @@
       "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=browse"
     },
     {
-      "label": "L&A / Absence Types / Form",
-      "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=add"
+      "label": "L&A / Absence Types / Leave Type Wizard / General Section",
+      "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=add",
+      "onReadyScript": "leave-type-wizard/leave-type-wizard-general-section.js"
+    },
+    {
+      "label": "L&A / Absence Types / Leave Type Wizard / Settings Section",
+      "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=add",
+      "onReadyScript": "leave-type-wizard/leave-type-wizard-settings-section.js"
+    },
+    {
+      "label": "L&A / Absence Types / Leave Type Wizard / Colour Picker",
+      "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=add",
+      "onReadyScript": "leave-type-wizard/leave-type-wizard-colour-picker.js"
+    },
+    {
+      "label": "L&A / Absence Types / Leave Type Wizard / Input Errors",
+      "url": "{{siteUrl}}/civicrm/admin/leaveandabsences/types?action=add",
+      "onReadyScript": "leave-type-wizard/leave-type-wizard-input-errors.js"
     }
   ]
 }


### PR DESCRIPTION
## Overview

This PR adds BackstopJS tests for Leave Type Wizard

## After

### First section (General section)

![civihr_la___absence_types___leave_type_wizard___general_section_0_document_0_desktop](https://user-images.githubusercontent.com/3973243/47431308-75b8a680-d793-11e8-8005-281ef1534a6b.png)

### Second section (Settings sections)

![civihr_la___absence_types___leave_type_wizard___settings_section_0_document_0_desktop](https://user-images.githubusercontent.com/3973243/47431311-76513d00-d793-11e8-81c7-ddb28bf75e95.png)

### Colour picker (Leave Type Wizard is the only place utilising it)

![civihr_la___absence_types___leave_type_wizard___colour_picker_0_document_0_desktop](https://user-images.githubusercontent.com/3973243/47431307-75b8a680-d793-11e8-8994-5327cb3531dd.png)

### Input errors (primarily for error/success badges)

![civihr_la___absence_types___leave_type_wizard___input_errors_0_document_0_desktop](https://user-images.githubusercontent.com/3973243/47431310-76513d00-d793-11e8-9173-c3ef1dfd416c.png)

## Comments

There is an open bug with Pupeteer https://github.com/GoogleChrome/puppeteer/issues/2977 which  throws `Node is either not visible or not an HTMLElement` on elements. It is not yet clear why it is caused and on which HTML elements and at which conditions, but it is confirmed as a bug given multiple people has reported this. Also the solution provided at the link mentioned above (https://github.com/GoogleChrome/puppeteer/issues/2977#issuecomment-412807613) helps, so we can assume this is the same bug as described.

```js
// doesn't work
this.puppet.click('.leave-type-wizard__next-section-button');

// doesn't work (times out)
this.puppet.waitFor('.leave-type-wizard__next-section-button', { visible: true });
this.puppet.click('.leave-type-wizard__next-section-button');

// works
await this.puppet.evaluate(() => {
  document.querySelector('.leave-type-wizard__next-section-button').click();
```
